### PR TITLE
Support managing TestFlight users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+# Custom config file for Rubocop static code analysis
+
+Metrics/LineLength:
+  Max: 160
+
+Metrics/MethodLength:
+  Max: 20
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in .gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
 
-Dir.glob('tasks/**/*.rake').each(&method(:import))
+Dir.glob("tasks/**/*.rake").each(&method(:import))
 
-task :default => :spec
+task default: :spec

--- a/bin/pilot
+++ b/bin/pilot
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-$:.push File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("../../lib", __FILE__)
 
-require 'pilot'
-require 'pilot/commands_generator'
+require "pilot"
+require "pilot/commands_generator"
 Pilot::CommandsGenerator.start

--- a/lib/pilot.rb
+++ b/lib/pilot.rb
@@ -1,11 +1,11 @@
-require 'json'
-require 'pilot/version'
-require 'pilot/manager'
-require 'pilot/tester_manager'
-require 'pilot/package_builder'
+require "json"
+require "pilot/version"
+require "pilot/manager"
+require "pilot/tester_manager"
+require "pilot/package_builder"
 
-require 'fastlane_core'
-require 'spaceship'
+require "fastlane_core"
+require "spaceship"
 
 module Pilot
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore

--- a/lib/pilot.rb
+++ b/lib/pilot.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'pilot/version'
 require 'pilot/manager'
+require 'pilot/tester_manager'
 require 'pilot/package_builder'
 
 require 'fastlane_core'

--- a/lib/pilot/commands_generator.rb
+++ b/lib/pilot/commands_generator.rb
@@ -37,9 +37,113 @@ module Pilot
         c.action do |args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
-          
+
           config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
           Pilot::Manager.new.run(config)
+        end
+      end
+
+      command :add_internal_tester do |c|
+        c.syntax = 'add_internal_tester'
+        c.description = 'Adds a new internal tester'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.add_internal_tester(config)
+        end
+      end
+
+      command :add_external_tester do |c|
+        c.syntax = 'add_external_tester'
+        c.description = 'Adds a new external tester'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.add_external_tester(config)
+        end
+      end
+
+      command :add_tester_to_app do |c|
+        c.syntax = 'add_tester_to_app'
+        c.description = 'Adds a tester to an app'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.add_tester_to_app(config)
+        end
+      end
+
+      command :find_tester do |c|
+        c.syntax = 'find_tester'
+        c.description = 'Find a tester (internal or external) by their email address'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.find_tester_by_email(config)
+        end
+      end
+
+      command :remove_internal_tester do |c|
+        c.syntax = 'remove_internal_tester'
+        c.description = 'Remove an internal tester by their email address'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.remove_internal_tester(config)
+        end
+      end
+
+      command :remove_tester do |c|
+        c.syntax = 'remove_tester'
+        c.description = 'Remove an external tester by their email address'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.remove_external_tester(config)
+        end
+      end
+
+      command :reinvite_internal_tester do |c|
+        c.syntax = 'reinvite_internal_tester'
+        c.description = 'Reinvite an internal tester'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.reinvite_internal_tester(config)
+        end
+      end
+
+      command :reinvite_tester do |c|
+        c.syntax = 'remove_tester'
+        c.description = 'Reinvite an external tester'
+        c.action do |args, options|
+
+          o = options.__hash__.dup
+          o.delete(:verbose)
+
+          config = FastlaneCore::Configuration.create(Pilot::Options.available_options, o)
+          Pilot::TesterManager.new.reinvite_external_tester(config)
         end
       end
 

--- a/lib/pilot/commands_generator.rb
+++ b/lib/pilot/commands_generator.rb
@@ -1,6 +1,6 @@
-require 'commander'
-require 'pilot/options'
-require 'fastlane_core'
+require "commander"
+require "pilot/options"
+require "fastlane_core"
 
 HighLine.track_eof = false
 
@@ -11,30 +11,28 @@ module Pilot
     FastlaneCore::CommanderGenerator.new.generate(Pilot::Options.available_options)
 
     def self.start
-      begin
-        FastlaneCore::UpdateChecker.start_looking_for_update('pilot')
-        self.new.run
-      ensure
-        FastlaneCore::UpdateChecker.show_update_status('pilot', Pilot::VERSION)
-      end
+      FastlaneCore::UpdateChecker.start_looking_for_update("pilot")
+      new.run
+    ensure
+      FastlaneCore::UpdateChecker.show_update_status("pilot", Pilot::VERSION)
     end
 
     def run
       program :version, Pilot::VERSION
       program :description, Pilot::DESCRIPTION
-      program :help, 'Author', 'Felix Krause <pilot@krausefx.com>'
-      program :help, 'Website', 'https://fastlane.tools'
-      program :help, 'GitHub', 'https://github.com/fastlane/pilot'
+      program :help, "Author", "Felix Krause <pilot@krausefx.com>"
+      program :help, "Website", "https://fastlane.tools"
+      program :help, "GitHub", "https://github.com/fastlane/pilot"
       program :help_formatter, :compact
 
-      global_option('--verbose') { $verbose = true }
+      global_option("--verbose") { $verbose = true }
 
       always_trace!
 
       command :fly do |c|
-        c.syntax = 'pilot'
-        c.description = 'Uploads a new binary to Apple TestFlight'
-        c.action do |args, options|
+        c.syntax = "pilot"
+        c.description = "Uploads a new binary to Apple TestFlight"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -44,10 +42,9 @@ module Pilot
       end
 
       command :add_internal_tester do |c|
-        c.syntax = 'add_internal_tester'
-        c.description = 'Adds a new internal tester'
-        c.action do |args, options|
-
+        c.syntax = "add_internal_tester"
+        c.description = "Adds a new internal tester"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -57,10 +54,9 @@ module Pilot
       end
 
       command :add_external_tester do |c|
-        c.syntax = 'add_external_tester'
-        c.description = 'Adds a new external tester'
-        c.action do |args, options|
-
+        c.syntax = "add_external_tester"
+        c.description = "Adds a new external tester"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -70,10 +66,9 @@ module Pilot
       end
 
       command :add_tester_to_app do |c|
-        c.syntax = 'add_tester_to_app'
-        c.description = 'Adds a tester to an app'
-        c.action do |args, options|
-
+        c.syntax = "add_tester_to_app"
+        c.description = "Adds a tester to an app"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -83,10 +78,9 @@ module Pilot
       end
 
       command :find_tester do |c|
-        c.syntax = 'find_tester'
-        c.description = 'Find a tester (internal or external) by their email address'
-        c.action do |args, options|
-
+        c.syntax = "find_tester"
+        c.description = "Find a tester (internal or external) by their email address"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -96,10 +90,9 @@ module Pilot
       end
 
       command :remove_internal_tester do |c|
-        c.syntax = 'remove_internal_tester'
-        c.description = 'Remove an internal tester by their email address'
-        c.action do |args, options|
-
+        c.syntax = "remove_internal_tester"
+        c.description = "Remove an internal tester by their email address"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -109,10 +102,9 @@ module Pilot
       end
 
       command :remove_tester do |c|
-        c.syntax = 'remove_tester'
-        c.description = 'Remove an external tester by their email address'
-        c.action do |args, options|
-
+        c.syntax = "remove_tester"
+        c.description = "Remove an external tester by their email address"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -122,10 +114,9 @@ module Pilot
       end
 
       command :reinvite_internal_tester do |c|
-        c.syntax = 'reinvite_internal_tester'
-        c.description = 'Reinvite an internal tester'
-        c.action do |args, options|
-
+        c.syntax = "reinvite_internal_tester"
+        c.description = "Reinvite an internal tester"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 
@@ -135,10 +126,9 @@ module Pilot
       end
 
       command :reinvite_tester do |c|
-        c.syntax = 'remove_tester'
-        c.description = 'Reinvite an external tester'
-        c.action do |args, options|
-
+        c.syntax = "remove_tester"
+        c.description = "Reinvite an external tester"
+        c.action do |_args, options|
           o = options.__hash__.dup
           o.delete(:verbose)
 

--- a/lib/pilot/manager.rb
+++ b/lib/pilot/manager.rb
@@ -1,4 +1,4 @@
-require 'fastlane_core'
+require "fastlane_core"
 
 module Pilot
   class Manager

--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -1,5 +1,5 @@
-require 'fastlane_core'
-require 'credentials_manager'
+require "fastlane_core"
+require "credentials_manager"
 
 module Pilot
   class Options
@@ -10,19 +10,19 @@ module Pilot
                                      env_name: "PILOT_USERNAME",
                                      description: "Your Apple ID Username",
                                      default_value: ENV["DELIVER_USER"] || CredentialsManager::AppfileConfig.try_fetch_value(:apple_id),
-                                     verify_block: Proc.new do |value|
+                                     verify_block: proc do |value|
                                        CredentialsManager::PasswordManager.shared_manager(value)
-                                    end),
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      env_name: "PILOT_IPA",
                                      description: "Path to the ipa file to upload",
                                      default_value: Dir["*.ipa"].first,
-                                     verify_block: Proc.new do |value|
-                                       raise "Could not find ipa file at path '#{value}'" unless File.exists?value
-                                       raise "'#{value}' doesn't seem to be an ipa file" unless value.end_with?".ipa"
-                                    end),
+                                     verify_block: proc do |value|
+                                       fail "Could not find ipa file at path '#{value}'" unless File.exist? value
+                                       fail "'#{value}' doesn't seem to be an ipa file" unless value.end_with? ".ipa"
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
@@ -30,9 +30,8 @@ module Pilot
                                      description: "The bundle identifier of the app to upload or manage testers (optional)",
                                      optional: true,
                                      default_value: ENV["TESTFLIGHT_APP_IDENTITIFER"],
-                                     verify_block: Proc.new do |value|
-
-                                    end),
+                                     verify_block: proc do |_value|
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :apple_id,
                                      short_option: "-p",
@@ -40,40 +39,39 @@ module Pilot
                                      description: "The unique App ID provided by iTunes Connect",
                                      optional: true,
                                      default_value: ENV["TESTFLIGHT_APPLE_ID"],
-                                     verify_block: Proc.new do |value|
-
-                                    end),
+                                     verify_block: proc do |_value|
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :first_name,
                                      short_option: "-f",
                                      env_name: "PILOT_TESTER_FIRST_NAME",
                                      description: "The tester's first name",
                                      optional: true,
-                                     verify_block: Proc.new do |value|
-                                    end),
+                                     verify_block: proc do |_value|
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :last_name,
                                      short_option: "-l",
                                      env_name: "PILOT_TESTER_FIRST_NAME",
                                      description: "The tester's last name",
                                      optional: true,
-                                     verify_block: Proc.new do |value|
-                                    end),
+                                     verify_block: proc do |_value|
+                                     end),
 
         FastlaneCore::ConfigItem.new(key: :email,
                                      short_option: "-e",
                                      env_name: "PILOT_TESTER_EMAIL",
                                      description: "The tester's email",
                                      optional: true,
-                                     verify_block: Proc.new do |value|
-                                    end),
+                                     verify_block: proc do |_value|
+                                     end),
         FastlaneCore::ConfigItem.new(key: :group_name,
                                      short_option: "-g",
                                      env_name: "PILOT_TESTER_GROUP",
                                      description: "Group to add the tester to",
                                      optional: true,
-                                     verify_block: Proc.new do |value|
-                                    end)        
+                                     verify_block: proc do |_value|
+                                     end)
 
       ]
     end

--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -12,7 +12,8 @@ module Pilot
                                      default_value: ENV["DELIVER_USER"] || CredentialsManager::AppfileConfig.try_fetch_value(:apple_id),
                                      verify_block: Proc.new do |value|
                                        CredentialsManager::PasswordManager.shared_manager(value)
-                                     end),
+                                    end),
+
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      env_name: "PILOT_IPA",
@@ -21,16 +22,18 @@ module Pilot
                                      verify_block: Proc.new do |value|
                                        raise "Could not find ipa file at path '#{value}'" unless File.exists?value
                                        raise "'#{value}' doesn't seem to be an ipa file" unless value.end_with?".ipa"
-                                     end),
+                                    end),
+
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "PILOT_APP_IDENTIFIER",
-                                     description: "The bundle identifier of the app to upload (optional)",
+                                     description: "The bundle identifier of the app to upload or manage testers (optional)",
                                      optional: true,
                                      default_value: ENV["TESTFLIGHT_APP_IDENTITIFER"],
                                      verify_block: Proc.new do |value|
-                                       
-                                     end),
+
+                                    end),
+
         FastlaneCore::ConfigItem.new(key: :apple_id,
                                      short_option: "-p",
                                      env_name: "PILOT_APPLE_ID",
@@ -38,9 +41,40 @@ module Pilot
                                      optional: true,
                                      default_value: ENV["TESTFLIGHT_APPLE_ID"],
                                      verify_block: Proc.new do |value|
-                                       
-                                     end)
-        
+
+                                    end),
+
+        FastlaneCore::ConfigItem.new(key: :first_name,
+                                     short_option: "-f",
+                                     env_name: "PILOT_TESTER_FIRST_NAME",
+                                     description: "The tester's first name",
+                                     optional: true,
+                                     verify_block: Proc.new do |value|
+                                    end),
+
+        FastlaneCore::ConfigItem.new(key: :last_name,
+                                     short_option: "-l",
+                                     env_name: "PILOT_TESTER_FIRST_NAME",
+                                     description: "The tester's last name",
+                                     optional: true,
+                                     verify_block: Proc.new do |value|
+                                    end),
+
+        FastlaneCore::ConfigItem.new(key: :email,
+                                     short_option: "-e",
+                                     env_name: "PILOT_TESTER_EMAIL",
+                                     description: "The tester's email",
+                                     optional: true,
+                                     verify_block: Proc.new do |value|
+                                    end),
+        FastlaneCore::ConfigItem.new(key: :group_name,
+                                     short_option: "-g",
+                                     env_name: "PILOT_TESTER_GROUP",
+                                     description: "Group to add the tester to",
+                                     optional: true,
+                                     verify_block: Proc.new do |value|
+                                    end)        
+
       ]
     end
   end

--- a/lib/pilot/package_builder.rb
+++ b/lib/pilot/package_builder.rb
@@ -1,4 +1,4 @@
-require 'digest/md5'
+require "digest/md5"
 
 module Pilot
   class PackageBuilder
@@ -11,10 +11,10 @@ module Pilot
       FileUtils.rm_rf self.package_path rescue nil
       FileUtils.mkdir_p self.package_path
 
-      lib_path = Helper.gem_path('pilot')
+      lib_path = Helper.gem_path("pilot")
 
       ipa_path = copy_ipa(ipa_path)
-      @data = { 
+      @data = {
         apple_id: apple_id,
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package

--- a/lib/pilot/tester_manager.rb
+++ b/lib/pilot/tester_manager.rb
@@ -1,0 +1,233 @@
+require 'fastlane_core'
+
+module Pilot
+  class TesterManager < Manager
+
+    @logged_in = false
+
+    def login
+      return if @logged_in
+
+      super
+      @logged_in = true
+    end
+
+    def tester_type_str(external)
+      external ? "external" : "internal"
+    end
+
+    def describe_tester(tester)
+
+      return if tester.nil?
+
+      puts "First name: #{tester.first_name}".green
+      puts "Last name: #{tester.last_name}".green
+      puts "Email: #{tester.email}".green
+
+      groups = tester.raw_data.get('groups')
+
+      if groups && groups.length > 0
+        group_names = groups.map { |group| group["name"]["value"] }
+        puts "Groups: #{group_names.join(', ')}".green
+      end
+
+      latestInstalledDate = tester.raw_data.get('latestInstalledDate')
+
+      if latestInstalledDate
+        latest_installed_version = tester.raw_data.get('latestInstalledVersion')
+        latest_installed_short_version = tester.raw_data.get('latestInstalledShortVersion')
+        pretty_date = Time.at((latestInstalledDate / 1000)).strftime("%m/%d/%y %H:%M")
+        puts "Installed version #{latest_installed_version} (#{latest_installed_short_version}) on #{pretty_date}".green
+      end
+
+      if tester.devices.length == 0
+        puts "No devices".green
+      else
+        puts "#{tester.devices.length} devices:".green
+        tester.devices.each do |device|
+          puts "\u2022 #{device['model']}, #{device['osVersion']}".green
+        end
+      end
+    end
+
+    ##
+
+    def add_external_tester(options)
+      add_tester(options, true)
+    end
+
+    def add_internal_tester(options)
+      add_tester(options, false)
+    end
+
+    def add_tester(options, external=true)
+      @config = options
+
+      tester_type = tester_type_str(external)
+
+      login
+
+      # tester = Spaceship::Tunes::Tester::External.new
+      # Helper.log.debug "Tester: #{tester}".green
+
+      begin
+        tester = nil
+
+        if external
+          tester = Spaceship::Tunes::Tester::External.create!(email: config[:email],
+                                                              first_name: config[:first_name],
+                                                              last_name: config[:last_name],
+                                                              group: config[:group_name])
+        else
+          tester = Spaceship::Tunes::Tester::External.create!(email: config[:email],
+                                                              first_name: config[:first_name],
+                                                              last_name: config[:last_name],
+                                                              group: config[:group_name])
+        end
+
+
+        if config[:apple_id]
+          puts "Adding #{tester_type} tester to app #{config[:apple_id]}".green
+          tester.add_to_app!(config[:apple_id])
+        end
+
+        # puts "Tester: #{tester::email}"
+        # puts "Tester: #{tester.first_name}"
+        # puts "Tester: #{tester.last_name}"
+        #
+        # Spaceship::Tunes::Tester::all
+
+        if tester
+          email = tester.email
+          puts "Invited #{tester_type} tester: #{email}".green
+        end
+      rescue => ex
+        puts "Could not create #{tester_type} tester: #{ex}".red
+        raise ex
+      end
+    end
+
+    def add_tester_to_app(options)
+
+      @config = options
+      login
+
+      email = config[:email]
+
+      tester = Spaceship::Tunes::Tester::Internal.find(email)
+      if tester.nil?
+        tester = Spaceship::Tunes::Tester::External.find(email)
+      end
+
+      if tester.nil?
+        puts "Tester not found: #{email}".red
+        return
+      end
+
+      the_app = app
+
+      app_id = the_app.apple_id
+
+      tester.add_to_app!(app_id)
+      puts "Added #{tester.email} to #{app.name}".green
+    end
+
+    ##
+
+    def find_tester_by_email(options, print_description = true)
+      @config = options
+      login
+
+      email = config[:email]
+
+      internal_tester = Spaceship::Tunes::Tester::Internal.find(email)
+      if internal_tester
+        puts "Found internal tester #{internal_tester.tester_id}".green
+        describe_tester(internal_tester) unless !print_description
+        return internal_tester
+      else
+        external_tester = Spaceship::Tunes::Tester::External.find(email)
+        if external_tester
+          puts "Found external tester #{internal_tester.tester_id}".green
+          describe_tester(external_tester) unless !print_description
+          return external_tester
+        else
+          puts "No tester found: #{email}".red
+        end
+      end
+    end
+
+    ##
+
+    def remove_tester(options, external=true)
+      tester_type = tester_type_str(external)
+
+      @config = options
+      login
+      email = config[:email]
+
+      tester = nil
+      if external
+        tester = Spaceship::Tunes::Tester::External.find(email)
+      else
+        tester = Spaceship::Tunes::Tester::Internal.find(email)
+      end
+
+      if tester
+        tester.delete!
+        puts "Removed #{tester_type} tester: #{tester.email}".green
+      else
+        puts "#{tester_type.capitalize} tester not found: #{email}".red
+      end
+    end
+
+    def remove_internal_tester(options)
+      remove_tester(options, false)
+    end
+
+    def remove_external_tester(options)
+      remove_tester(options, true)
+    end
+
+    ##
+
+    def reinvite_internal_tester(options)
+      reinvite_tester(options, false)
+    end
+
+    def reinvite_external_tester(options)
+      reinvite_tester(options, true)
+    end
+
+    def reinvite_tester(options, external=true)
+      @config = options
+      login
+
+      tester_type = tester_type_str(external)
+      email = config[:email]
+
+      tester = nil
+      if external
+        tester = Spaceship::Tunes::Tester::External.find(email)
+      else
+        tester = Spaceship::Tunes::Tester::Internal.find(email)
+      end
+
+      if tester
+        puts "Reinviting tester"
+
+        options[:first_name] = tester.first_name
+        options[:last_name] = tester.last_name
+
+        tester.delete!
+
+        new_tester = add_tester(options, external)
+
+        describe_tester(new_tester)
+      else
+        puts "#{tester_type.capitalize} not found: #{email}".green
+      end
+    end
+
+  end
+end

--- a/lib/pilot/tester_manager.rb
+++ b/lib/pilot/tester_manager.rb
@@ -1,8 +1,7 @@
-require 'fastlane_core'
+require "fastlane_core"
 
 module Pilot
   class TesterManager < Manager
-
     @logged_in = false
 
     def login
@@ -17,25 +16,23 @@ module Pilot
     end
 
     def describe_tester(tester)
-
       return if tester.nil?
 
       puts "First name: #{tester.first_name}".green
       puts "Last name: #{tester.last_name}".green
       puts "Email: #{tester.email}".green
 
-      groups = tester.raw_data.get('groups')
+      groups = tester.raw_data.get("groups")
 
       if groups && groups.length > 0
         group_names = groups.map { |group| group["name"]["value"] }
         puts "Groups: #{group_names.join(', ')}".green
       end
 
-      latestInstalledDate = tester.raw_data.get('latestInstalledDate')
-
+      latestInstalledDate = tester.raw_data.get("latestInstalledDate")
       if latestInstalledDate
-        latest_installed_version = tester.raw_data.get('latestInstalledVersion')
-        latest_installed_short_version = tester.raw_data.get('latestInstalledShortVersion')
+        latest_installed_version = tester.raw_data.get("latestInstalledVersion")
+        latest_installed_short_version = tester.raw_data.get("latestInstalledShortVersion")
         pretty_date = Time.at((latestInstalledDate / 1000)).strftime("%m/%d/%y %H:%M")
         puts "Installed version #{latest_installed_version} (#{latest_installed_short_version}) on #{pretty_date}".green
       end
@@ -60,7 +57,7 @@ module Pilot
       add_tester(options, false)
     end
 
-    def add_tester(options, external=true)
+    def add_tester(options, external = true)
       @config = options
 
       tester_type = tester_type_str(external)
@@ -85,7 +82,6 @@ module Pilot
                                                               group: config[:group_name])
         end
 
-
         if config[:apple_id]
           puts "Adding #{tester_type} tester to app #{config[:apple_id]}".green
           tester.add_to_app!(config[:apple_id])
@@ -108,16 +104,13 @@ module Pilot
     end
 
     def add_tester_to_app(options)
-
       @config = options
       login
 
       email = config[:email]
 
       tester = Spaceship::Tunes::Tester::Internal.find(email)
-      if tester.nil?
-        tester = Spaceship::Tunes::Tester::External.find(email)
-      end
+      tester = Spaceship::Tunes::Tester::External.find(email) if tester.nil?
 
       if tester.nil?
         puts "Tester not found: #{email}".red
@@ -143,13 +136,13 @@ module Pilot
       internal_tester = Spaceship::Tunes::Tester::Internal.find(email)
       if internal_tester
         puts "Found internal tester #{internal_tester.tester_id}".green
-        describe_tester(internal_tester) unless !print_description
+        describe_tester(internal_tester) if print_description
         return internal_tester
       else
         external_tester = Spaceship::Tunes::Tester::External.find(email)
         if external_tester
           puts "Found external tester #{internal_tester.tester_id}".green
-          describe_tester(external_tester) unless !print_description
+          describe_tester(external_tester) if print_description
           return external_tester
         else
           puts "No tester found: #{email}".red
@@ -159,7 +152,7 @@ module Pilot
 
     ##
 
-    def remove_tester(options, external=true)
+    def remove_tester(options, external = true)
       tester_type = tester_type_str(external)
 
       @config = options
@@ -199,7 +192,7 @@ module Pilot
       reinvite_tester(options, true)
     end
 
-    def reinvite_tester(options, external=true)
+    def reinvite_tester(options, external = true)
       @config = options
       login
 
@@ -228,6 +221,5 @@ module Pilot
         puts "#{tester_type.capitalize} not found: #{email}".green
       end
     end
-
   end
 end

--- a/lib/pilot/version.rb
+++ b/lib/pilot/version.rb
@@ -1,4 +1,4 @@
 module Pilot
   VERSION = "0.1.1"
-  DESCRIPTION = %q{The unofficial TestFlight CLI to upload builds and manage testers}
+  DESCRIPTION = "The unofficial TestFlight CLI to upload builds and manage testers"
 end

--- a/pilot.gemspec
+++ b/pilot.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'pilot/version'
+require "pilot/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "pilot"
@@ -13,24 +13,24 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://fastlane.tools"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = ">= 2.0.0"
 
-  spec.files = Dir["lib/**/*"] + %w{ bin/pilot README.md LICENSE }
+  spec.files = Dir["lib/**/*"] + %w(bin/pilot README.md LICENSE)
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.7.2' # all shared code and dependencies
-  spec.add_dependency 'spaceship', '>= 0.1.0' # iTunes Connect communication
-  spec.add_dependency 'credentials_manager', '>= 0.3.0'
-  
+  spec.add_dependency "fastlane_core", ">= 0.7.2" # all shared code and dependencies
+  spec.add_dependency "spaceship", ">= 0.1.0" # iTunes Connect communication
+  spec.add_dependency "credentials_manager", ">= 0.3.0"
+
   # Development only
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.1.0'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'yard', '~> 0.8.7.4'
-  spec.add_development_dependency 'webmock', '~> 1.19.0'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "yard", "~> 0.8.7.4"
+  spec.add_development_dependency "webmock", "~> 1.19.0"
+  spec.add_development_dependency "coveralls"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,20 @@
-require 'coveralls'
+require "coveralls"
 Coveralls.wear! unless ENV["FASTLANE_SKIP_UPDATE_CHECK"]
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper
-  
 end
 
-require 'pilot'
-require 'webmock/rspec'
+require "pilot"
+require "webmock/rspec"
 
 # Own mocking code
 # require 'mocking/webmocking'
 # require 'mocking/transporter_mocking'
 
-
 ENV["DELIVER_USER"] = "DELIVERUSER"
 ENV["DELIVER_PASSWORD"] = "DELIVERPASS"
 ENV["DELIVER_HTML_EXPORT_PATH"] = "/tmp" # to not pollute the working directory
-
-
 
 # RSpec.configure do |config|
 #   config.after(:each) do |test|

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,3 +1,3 @@
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
This PR adds these features:
- [x] Add an internal/external tester
- [x] Find a tester by email address
- [x] Remove an internal/external tester
- [x] Re-invite (remove/re-add) a tester

Tests to come soon :+1: 
