### PR TITLE
Make wait_for_processing interval configurable

### DIFF
--- a/lib/pilot/build_manager.rb
+++ b/lib/pilot/build_manager.rb
@@ -64,10 +64,11 @@ module Pilot
       # the upload date of the new buid
       # we use it to identify the build
 
+      wait_processing_interval = config[:wait_processing_interval].to_i
       latest_build = nil
       loop do
         Helper.log.info "Waiting for iTunes Connect to process the new build"
-        sleep 30
+        sleep wait_processing_interval
         builds = app.all_processing_builds
         break if builds.count == 0
         latest_build = builds.last # store the latest pre-processing build here
@@ -83,7 +84,7 @@ module Pilot
         end
 
         Helper.log.info "Waiting for iTunes Connect to finish processing the new build (#{full_build.train_version} - #{full_build.build_version})"
-        sleep 5
+        sleep wait_processing_interval
       end
 
       if full_build

--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -66,7 +66,15 @@ module Pilot
                                      env_name: "PILOT_TESTERS_FILE",
                                      description: "Path to a CSV file of testers",
                                      default_value: "./testers.csv",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :wait_processing_interval,
+                                     short_option: "-k",
+                                     env_name: "PILOT_WAIT_PROCESSING_INTERVAL",
+                                     description: "Interval in seconds to wait for iTunes Connect processing",
+                                     default_value: "30",
+                                     verify_block: proc do |value|
+                                       raise "Please enter a valid positive number of seconds" unless value.to_i > 0
+                                     end)
 
       ]
     end


### PR DESCRIPTION
Running `pilot` on CI server, it takes about 5 mins in iTunes Connect for the build to appear in "Processing" state and about 15 mins for the build to be processed. That means ~10 network requests for the former (current sleep time 30 seconds) and more then 100 network requests for the latter (second current sleep 5 seconds only).

Network requests sometimes fail or timeout (it happens), would be nice for pilot to retry instead of failing in case of a failed network request, but for now this makes the `wait_processing_interval` configurable so we can reduce the number of network requests and the probability of false positives.
