### PR TITLE
Added option to pass and use version and build to upload task.

### DIFF
--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -75,8 +75,16 @@ module Pilot
                                      is_string: false,
                                      verify_block: proc do |value|
                                        raise "Please enter a valid positive number of seconds" unless value.to_i > 0
-                                     end)
-
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :build_full_version,
+                                     short_option: "-b",
+                                     env_name: "PILOT_BUILD_FULL_VERSION",
+                                     description: "Build version with format version(build_number), ex 1.0(12)",
+                                     is_string: true,
+                                     optional: true,
+                                     verify_block: proc do |value|
+x                                       raise "Please use valid format, ex 1.0(12)" unless (value =~ /.*\(.*\)/)
+                                       end)
       ]
     end
   end


### PR DESCRIPTION
Hi, 
I have a constant problem with some processing builds. They are processing forever:
![builds](https://cloud.githubusercontent.com/assets/3447934/11090634/90c5e2dc-8884-11e5-8a29-8219dc7e2e65.jpg)

That is why I have to add option -b build_full_version with description: "Build version with format version(build_number), ex 1.0(12)" to use it in build_manager. This option is used to find uploaded build.
