### PR TITLE
Added option for using version and build to upload task.

### DIFF
--- a/lib/pilot/build_manager.rb
+++ b/lib/pilot/build_manager.rb
@@ -27,7 +27,7 @@ module Pilot
         raise "Error uploading ipa file, more information see above".red
       end
     end
-    
+
     def list(options)
       start(options)
       if config[:apple_id].to_s.length == 0 and config[:app_identifier].to_s.length == 0
@@ -104,12 +104,12 @@ module Pilot
 
       if could_determine_uploaded_build?
         # stop if there is not build with valid version in pre-processing builds
-        should_stop = lambda {|builds| builds.select{|build| is_uploaded_build(build)}.count == 0 }
+        should_stop = ->(builds) { builds.count { |build| uploaded_build?(build) } == 0 }
         # store pre-processing build with valid version here
-        obtain_processing_build = lambda {|builds| builds.find{|build| is_uploaded_build(build)} }
+        obtain_processing_build = ->(builds) { builds.find { |build| uploaded_build?(build) } }
       else
-        should_stop = lambda {|builds| builds.count == 0 }
-        obtain_processing_build = lambda {|builds| builds.last } # store the latest pre-processing build here
+        should_stop = ->(builds) { builds.count == 0 }
+        obtain_processing_build = ->(builds) { builds.last } # store the latest pre-processing build here
       end
 
       loop do
@@ -138,7 +138,7 @@ module Pilot
       !config[:build_full_version].nil?
     end
 
-    def is_uploaded_build(build)
+    def uploaded_build?(build)
       build_full_version = "#{build.train_version}(#{build.build_version})"
       config[:build_full_version] == build_full_version
     end

--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -83,8 +83,8 @@ module Pilot
                                      is_string: true,
                                      optional: true,
                                      verify_block: proc do |value|
-x                                       raise "Please use valid format, ex 1.0(12)" unless (value =~ /.*\(.*\)/)
-                                       end)
+                                       raise "Please use valid format, ex 1.0(12)" unless value =~ /.*\(.*\)/
+                                     end)
       ]
     end
   end

--- a/lib/pilot/options.rb
+++ b/lib/pilot/options.rb
@@ -75,8 +75,16 @@ module Pilot
                                      is_string: false,
                                      verify_block: proc do |value|
                                        raise "Please enter a valid positive number of seconds" unless value.to_i > 0
-                                     end)
-
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :build_full_version,
+                                     short_option: "-b",
+                                     env_name: "PILOT_BUILD_FULL_VERSION",
+                                     description: "Build version with format version(build_number), ex 1.0(12)",
+                                     is_string: true,
+                                     optional: true,
+                                     verify_block: proc do |value|
+x                                       raise "Please use valid format, ex 1.0(12)" unless (value =~ /.*\(.*\)/)
+                                       end)
       ]
     end
   end


### PR DESCRIPTION
Hi, 
I have a constant problem with some processing builds. They are processing forever:
builds
![builds](https://cloud.githubusercontent.com/assets/3447934/11092842/68845f34-8897-11e5-913e-04684f3b4ff0.jpg)

That is why I have to add option -b build_full_version with description: "Build version with format version(build_number), ex 1.0(12)" to use it in build_manager. This option is used to find uploaded build.